### PR TITLE
Minor fixes

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -8,7 +8,7 @@
 
   settings = {
     api_key: false,
-    hostname: 'instrumentalapp.com',
+    hostname: 'collector.instrumentalapp.com',
     port: 8000,
     timeout: 10000,
     max_queue_size: 100
@@ -111,7 +111,7 @@
       if (timestamp === null) {
         timestamp = Math.round(+new Date() / 1000);
       }
-      return queue_api("gauge", [metric, increment_by, timestamp]);
+      return queue_api("gauge", [metric, measurement, timestamp]);
     },
     gauge_absolute: function(metric, measurement, timestamp) {
       if (timestamp == null) {
@@ -120,7 +120,7 @@
       if (timestamp === null) {
         timestamp = Math.round(+new Date() / 1000);
       }
-      return queue_api("gauge_absolute", [metric, increment_by, timestamp]);
+      return queue_api("gauge_absolute", [metric, measurement, timestamp]);
     },
     notice: function(event, duration, timestamp) {
       if (duration == null) {


### PR DESCRIPTION
Instrumental updated their collection endpoint from "instrumentalapp.com" to "collector.instrumentalapp.com"  [https://instrumentalapp.com/docs/collector%2Freadme]

Fix 'gauge' and 'gauge_absolute' functions to use the correct variable names
